### PR TITLE
Change to make press releases link to `source_url`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "type": "package",
             "package": {
               "name": "misfist/pai",
-                "version": "0.2.0",
+                "version": "0.2.2",
                 "type": "wordpress-theme",
                 "dist": {
                     "type": "zip",
@@ -117,7 +117,7 @@
       "wpackagist-theme/understrap": "^0.5.6",
       "misfist/pai-core-functionality": "^0.1.7",
       "misfist/littlesis-core-functionality": "^0.1.4",
-      "misfist/pai": "^0.2.0",
+      "misfist/pai": "^0.2.2",
       "public-accountability/littlesis": "^0.1.16"
     },
     "require-dev": {


### PR DESCRIPTION
Updated composer.json with updated version of theme.

https://github.com/public-accountability/pai/releases/tag/0.2.2